### PR TITLE
[GEN-1084] Increase memory for create_consortium_release and even out process_maf

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -20,7 +20,7 @@ profiles {
 	aws_prod {
 		process {
 			withName: process_maf {
-				memory = 60.GB
+				memory = 64.GB
 				cpus = 16
 			}
 			withName: process_main {
@@ -32,7 +32,7 @@ profiles {
 				cpus = 4
 			}
 			withName: create_consortium_release {
-				memory = 16.GB
+				memory = 32.GB
 				cpus = 4
 			}
 			withName: create_public_release {


### PR DESCRIPTION
**Problem**

create_consortium_release seems to be failing due to memory issues.   In particular, the maf in bed filter running R code.

**Solution**
Bump the memory to get processing across.

