### PR TITLE
[GEN-1170] Add missing profile to data guide

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Sage-Bionetworks/genie-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Sage-Bionetworks/genie-reviewers
+* @Sage-Bionetworks-Workflows/genie

--- a/scripts/data_guide/genomic_profiles/gold.qmd
+++ b/scripts/data_guide/genomic_profiles/gold.qmd
@@ -1,0 +1,3 @@
+### GOLD center
+
+This is a test profile for the test center: GOLD

--- a/scripts/data_guide/genomic_profiles/gold.qmd
+++ b/scripts/data_guide/genomic_profiles/gold.qmd
@@ -1,3 +1,3 @@
 ### GOLD center
 
-This is a test profile for the test center: GOLD
+This is a test profile for the test center GOLD


### PR DESCRIPTION
**Purpose:** Adds the missing center profile for our GOLD center. The docker image tagged at `sagebionetworks/genie-data-guide:latest` on dockerhub needs to be rebuilt in order for this to work on Nextflow Workflow Tower.

I don't have the permissions to push to `sagebionetworks` on dockerhub, but tested `consortium_release` on `nf-genie` on the rebuilt image locally and it works (data guide on test pipeline gets outputted): https://www.synapse.org/#!Synapse:syn21895009 

Once this gets pushed to main, the docker image will rebuild on dockerhub, and the nextflow workflow tower run will work