### PR TITLE
[GEN-1157] Fix copying of data guide to BPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ Add `-with-docker <docker_image_name>` to every nextflow command to invoke the s
     nextflow run main.nf --process_type public_release -with-docker sagebionetworks/genie:latest
     ```
 
+### Testing
+
+Run unit tests from the root of the repo. These unit tests cover the code in the `scripts/` directory.
+
+```
+python3 -m pytest tests
+```
+
+Unit tests have to be run manually for now. You will need
+`pandas` and `synapseclient` to run them. See [Dockerfile](https://github.com/Sage-Bionetworks-Workflows/nf-genie/blob/main/scripts/release_utils/Dockerfile) for the version of `synapseclient` to use.
+
 ## Processing on Nextflow Tower
 
 Follow instructions here for running the main GENIE processing directly on Nextflow tower

--- a/main.nf
+++ b/main.nf
@@ -118,9 +118,9 @@ workflow {
     process_main(process_maf.out, ch_project_id, ch_center)
     create_consortium_release(process_main.out, ch_release, ch_is_prod, ch_seq_date)
     create_data_guide(create_consortium_release.out, ch_release, ch_project_id)
+    load_to_bpc(create_data_guide.out, ch_release, ch_is_prod)
     if (is_prod) {
       find_maf_artifacts(create_consortium_release.out, ch_release)
-      load_to_bpc(create_consortium_release.out, ch_release)
       check_for_retractions(create_consortium_release.out)
     }
   } else if (params.process_type == "public_release") {

--- a/modules/load_to_bpc.nf
+++ b/modules/load_to_bpc.nf
@@ -5,12 +5,20 @@ process load_to_bpc {
     input:
     val previous
     val release
+    val production
 
     output:
     stdout
 
     script:
-    """
-    python3 /release_utils/consortium_to_bpc.py $release
-    """
+    if (production) {
+        """
+        python3 /release_utils/consortium_to_bpc.py $release
+        """
+    }
+    else {
+        """
+        python3 /release_utils/consortium_to_bpc.py $release --test
+        """
+    }
 }

--- a/scripts/release_utils/consortium_to_bpc.py
+++ b/scripts/release_utils/consortium_to_bpc.py
@@ -9,9 +9,9 @@ from synapseclient import Folder
 import synapseutils as synu
 
 
-def get_genie_folder_synids(test: bool = False) -> Dict[str, str]:
+def get_release_synids(test: bool = False) -> Dict[str, str]:
     """Retrieves the set of synapse ids associated with the
-       test or production versions of the entities in the main genie synapse project
+       test or production versions of the entities associated with the release
 
     Args:
         test (bool, optional): Whether this is using the test project or not
@@ -76,7 +76,12 @@ def remove_gene_panels(syn, file_mapping, remove_seqassays, remove_centers):
 
 
 def main(release: str, test: bool) -> None:
-    """Updates BPC project"""
+    """Updated BPC project 
+
+    Args:
+        release (str): name of the release 
+        test (bool): testing or not
+    """
     # if release.endswith("1-consortium"):
     #     raise ValueError("First consortium release are not released")
 

--- a/scripts/release_utils/consortium_to_bpc.py
+++ b/scripts/release_utils/consortium_to_bpc.py
@@ -76,10 +76,9 @@ def remove_gene_panels(syn, file_mapping, remove_seqassays, remove_centers):
 
 
 def main(release: str, test: bool) -> None:
-    """Updated BPC project 
-
+    """Updated BPC project
     Args:
-        release (str): name of the release 
+        release (str): name of the release
         test (bool): testing or not
     """
     # if release.endswith("1-consortium"):
@@ -87,7 +86,7 @@ def main(release: str, test: bool) -> None:
 
     syn = synapseclient.login()
 
-    ent_synids = get_genie_folder_synids(test)
+    ent_synids = get_release_synids(test)
 
     # Finds the synid of the release
     release_synid = find_release(

--- a/scripts/release_utils/consortium_to_bpc.py
+++ b/scripts/release_utils/consortium_to_bpc.py
@@ -1,29 +1,72 @@
 """Most current consortium release cBioPortal files to BPC Synapse Project
 Consortium releases to internal BPC page"""
+
 import argparse
+from typing import Dict
 
 import synapseclient
 from synapseclient import Folder
 import synapseutils as synu
 
 
-DATA_FOLDER_SYNID = "syn21574209"
-RELEASE_TABLE = "syn16804261"
+def get_genie_folder_synids(test: bool = False) -> Dict[str, str]:
+    """Retrieves the set of synapse ids associated with the
+       test or production versions of the entities in the main genie synapse project
+
+    Args:
+        test (bool, optional): Whether this is using the test project or not
+            Defaults to False.
+
+    Returns:
+        Dict[str, str]: mapping of the synapse entity name to the synapse id
+    """
+    if test:
+        return {
+            "data_folder_synid": "syn53879650",
+            "release_table_synid": "syn12299959",
+        }
+    else:
+        return {
+            "data_folder_synid": "syn21574209",
+            "release_table_synid": "syn16804261",
+        }
 
 
-def find_release(syn, release):
-    """Finds the Synapse id of a private consortium release folder"""
-    release_synid = syn.tableQuery("select distinct(parentId) from {} where "
-                                   "release = '{}'".format(RELEASE_TABLE,
-                                                           release))
-    releasedf = release_synid.asDataFrame()
-    if releasedf.empty:
-        raise ValueError("Please specify correct release value")
-    return releasedf.iloc[0,0]
+def find_release(
+    syn: synapseclient.Synapse, release: str, release_table_synid: str, test: bool
+) -> str:
+    """Finds the Synapse id of a private consortium release folder
+
+    Args:
+        syn (synapseclient.Synapse): synaspe client connection
+        release (str): name of the consortium release
+        release_table_synid (str): synapse id of the release table
+        test (bool, optional): Whether this is using the test project or not
+
+    Raises:
+        ValueError: raised if no table record exists for the specified release
+
+    Returns:
+        str: the synapse id of the release folder
+    """
+    if test:
+        # use the release folder directly
+        return release_table_synid
+    else:
+        release_synid = syn.tableQuery(
+            "select distinct(parentId) from {} where "
+            "release = '{}'".format(release_table_synid, release)
+        )
+        releasedf = release_synid.asDataFrame()
+        if releasedf.empty:
+            raise ValueError("Please specify correct release value")
+        return releasedf.iloc[0, 0]
 
 
 def remove_gene_panels(syn, file_mapping, remove_seqassays, remove_centers):
-    """Removes gene panels that shouldn't be there"""
+    """ NOTE: Is this still needed?
+        Removes gene panels that shouldn't be there
+    """
     for name in file_mapping:
         gene_name = name.replace("data_gene_panel_", "").replace(".txt", "")
         if gene_name in remove_seqassays or gene_name.startswith(tuple(remove_centers)):
@@ -32,64 +75,74 @@ def remove_gene_panels(syn, file_mapping, remove_seqassays, remove_centers):
             syn.delete(file_mapping[name])
 
 
-def main(release):
+def main(release: str, test: bool) -> None:
     """Updates BPC project"""
     # if release.endswith("1-consortium"):
     #     raise ValueError("First consortium release are not released")
 
     syn = synapseclient.login()
+
+    ent_synids = get_genie_folder_synids(test)
+
     # Finds the synid of the release
-    release_synid = find_release(syn, release)
+    release_synid = find_release(
+        syn,
+        release=release,
+        release_table_synid=ent_synids["release_table_synid"],
+        test=test,
+    )
 
     # Get existing BPC cBioPortal release files
     major_release = release.split(".")[0]
     release_folder_ent = syn.store(
-        Folder(f"Release {major_release}", parent=DATA_FOLDER_SYNID)
+        Folder(f"Release {major_release}", parent=ent_synids["data_folder_synid"])
     )
-    bpc_folder_ent = syn.store(Folder(release,
-                                      parent=release_folder_ent))
-    caselist_folder_ent = syn.store(Folder("case_lists",
-                                           parent=bpc_folder_ent))
-    genepanel_folder_ent = syn.store(Folder("gene_panels",
-                                            parent=bpc_folder_ent))
+    bpc_folder_ent = syn.store(Folder(release, parent=release_folder_ent))
+    caselist_folder_ent = syn.store(Folder("case_lists", parent=bpc_folder_ent))
+    genepanel_folder_ent = syn.store(Folder("gene_panels", parent=bpc_folder_ent))
 
     # Get existing gene panels
     existing_gene_panels = syn.getChildren(genepanel_folder_ent)
-    genepanel_map = {exist['name']: exist['id']
-                     for exist in existing_gene_panels}
+    genepanel_map = {exist["name"]: exist["id"] for exist in existing_gene_panels}
     # Get existing case lists
     case_list = syn.getChildren(caselist_folder_ent)
-    caselist_map = {case['name']: case['id'] for case in case_list}
+    caselist_map = {case["name"]: case["id"] for case in case_list}
 
     # Get release files
     release_files = syn.getChildren(release_synid)
-    synid_map = {release['name']: release['id'] for release in release_files}
+    synid_map = {release["name"]: release["id"] for release in release_files}
 
     # Copy gene panel files
     for name in synid_map:
         if name.startswith("data_gene_panel_"):
-            ent = syn.get(synid_map[name], followLink=True,
-                          downloadFile=False)
-            synu.copy(syn, ent, genepanel_folder_ent.id,
-                      setProvnance=None,
-                      updateExisting=True,
-                      skipCopyAnnotations=True)
+            ent = syn.get(synid_map[name], followLink=True, downloadFile=False)
+            synu.copy(
+                syn,
+                ent,
+                genepanel_folder_ent.id,
+                setProvnance=None,
+                updateExisting=True,
+                skipCopyAnnotations=True,
+            )
     # Remove gene panels
     for name in genepanel_map:
         if name not in synid_map:
             print("Removing: {}({})".format(name, genepanel_map[name]))
             syn.delete(genepanel_map[name])
 
-    new_caselists = syn.getChildren(synid_map['case_lists'])
-    new_caselist_map = {case['name']: case['id'] for case in new_caselists}
+    new_caselists = syn.getChildren(synid_map["case_lists"])
+    new_caselist_map = {case["name"]: case["id"] for case in new_caselists}
     # Copy case lists
     for name in new_caselist_map:
-        ent = syn.get(new_caselist_map[name], followLink=True,
-                      downloadFile=False)
-        synu.copy(syn, ent, caselist_folder_ent.id,
-                  setProvnance=None,
-                  updateExisting=True,
-                  skipCopyAnnotations=True)
+        ent = syn.get(new_caselist_map[name], followLink=True, downloadFile=False)
+        synu.copy(
+            syn,
+            ent,
+            caselist_folder_ent.id,
+            setProvnance=None,
+            updateExisting=True,
+            skipCopyAnnotations=True,
+        )
 
     # Remove case lists
     for name in caselist_map:
@@ -102,21 +155,23 @@ def main(release):
         # Do not copy over files with these patterns
         # exclude = name.startswith(("data_gene_panel_", "data_clinical.txt",
         #                            "case_lists")) or name.endswith(".html")
-        if not name.startswith(("data_gene_panel_", "data_clinical.txt",
-                                "case_lists")):
-            ent = syn.get(synid_map[name], followLink=True,
-                          downloadFile=False)
-            synu.copy(syn, ent, bpc_folder_ent.id,
-                      setProvnance=None,
-                      updateExisting=True,
-                      skipCopyAnnotations=True)
+        if not name.startswith(("data_gene_panel_", "data_clinical.txt", "case_lists")):
+            ent = syn.get(synid_map[name], followLink=True, downloadFile=False)
+            synu.copy(
+                syn,
+                ent,
+                bpc_folder_ent.id,
+                setProvnance=None,
+                updateExisting=True,
+                skipCopyAnnotations=True,
+            )
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Consortium to BPC')
-    parser.add_argument("release",
-                        type=str,
-                        metavar="8.2-consortium",
-                        help="GENIE release version")
+    parser = argparse.ArgumentParser(description="Consortium to BPC")
+    parser.add_argument(
+        "release", type=str, metavar="8.2-consortium", help="GENIE release version"
+    )
+    parser.add_argument("--test", action="store_true", help="Testing")
     args = parser.parse_args()
-    main(args.release)
+    main(args.release, args.test)

--- a/tests/scripts/release_utils/test_consortium_to_bpc.py
+++ b/tests/scripts/release_utils/test_consortium_to_bpc.py
@@ -8,8 +8,9 @@ from scripts.release_utils import consortium_to_bpc as to_bpc
 
 
 @pytest.fixture(scope="session")
-def syn():
+def syn() -> synapseclient.Synapse:
     return mock.create_autospec(synapseclient.Synapse)
+
 
 @pytest.mark.parametrize(
     "is_test, expected",
@@ -61,7 +62,7 @@ def test_that_find_release_does_expected_calls_if_test_false(syn):
                 syn, release="TEST", release_table_synid="synZZZZ", test=False
             )
             patch_table_query.assert_called_once_with(
-                "select distinct(parentId) from synZZZZ where " "release = 'TEST'"
+                "select distinct(parentId) from synZZZZ where release = 'TEST'"
             )
             assert release_synid == "synYYYY"
 

--- a/tests/scripts/release_utils/test_consortium_to_bpc.py
+++ b/tests/scripts/release_utils/test_consortium_to_bpc.py
@@ -1,0 +1,75 @@
+from unittest import mock
+
+import pandas as pd
+import pytest
+import synapseclient
+
+from scripts.release_utils import consortium_to_bpc as to_bpc
+
+
+@pytest.fixture(scope="session")
+def syn():
+    return mock.create_autospec(synapseclient.Synapse)
+
+@pytest.mark.parametrize(
+    "is_test, expected",
+    [
+        (
+            True,
+            {
+                "data_folder_synid": "syn53879650",
+                "release_table_synid": "syn12299959",
+            },
+        ),
+        (
+            False,
+            {
+                "data_folder_synid": "syn21574209",
+                "release_table_synid": "syn16804261",
+            },
+        ),
+    ],
+    ids=["test_is_true", "test_is_false"],
+)
+def test_that_release_synids_returns_expected(is_test, expected):
+    result = to_bpc.get_release_synids(test=is_test)
+    assert result == expected
+
+
+def test_that_find_release_raises_error_if_empty_release_table(syn):
+    with mock.patch.object(syn, "tableQuery") as patch_table_query:
+        table_mock = mock.MagicMock()
+        patch_table_query.return_value = table_mock
+
+        with mock.patch.object(
+            table_mock, "asDataFrame", return_value=pd.DataFrame()
+        ), pytest.raises(ValueError, match="Please specify correct release value"):
+            to_bpc.find_release(
+                syn, release="TEST", release_table_synid="synZZZZ", test=False
+            )
+
+
+def test_that_find_release_does_expected_calls_if_test_false(syn):
+    with mock.patch.object(syn, "tableQuery") as patch_table_query:
+        table_mock = mock.MagicMock()
+        patch_table_query.return_value = table_mock
+
+        with mock.patch.object(
+            table_mock, "asDataFrame", return_value=pd.DataFrame({"col1": ["synYYYY"]})
+        ):
+            release_synid = to_bpc.find_release(
+                syn, release="TEST", release_table_synid="synZZZZ", test=False
+            )
+            patch_table_query.assert_called_once_with(
+                "select distinct(parentId) from synZZZZ where " "release = 'TEST'"
+            )
+            assert release_synid == "synYYYY"
+
+
+def test_that_find_release_does_expected_calls_if_test_true(syn):
+    with mock.patch.object(syn, "tableQuery") as patch_table_query:
+        release_synid = to_bpc.find_release(
+            syn, release="TEST", release_table_synid="synZZZZ", test=True
+        )
+        patch_table_query.assert_not_called()
+        assert release_synid == "synZZZZ"


### PR DESCRIPTION
**Purpose:** As part of each consortium release, we copy the files over to the BPC folder here. The data guide wasn't copying before because of the logic of the workflow not requiring that `create_data_guide` finish running before running `load_to_bpc`. 

This PR fixes that AND adds the ability to integration test `load_to_bpc` in the test synapse project (which we didn't have before). I also added unit tests to the code that gets affected by this.

**Changes:**
- Most changes are syntax/formatting changes using `black` for linting, notable changes are below:
- Addition of the function [get_release_synids](https://github.com/Sage-Bionetworks-Workflows/nf-genie/blob/gen-1157-fix-data-guide-copying/scripts/release_utils/consortium_to_bpc.py#L12-L32) to pull test and production versions of the synapse entities involved in the copying 
- Changes to function [find_release](https://github.com/Sage-Bionetworks-Workflows/nf-genie/blob/gen-1157-fix-data-guide-copying/scripts/release_utils/consortium_to_bpc.py#L35-L63) to add a testing mode
- [Adding new parser argument `test`](https://github.com/Sage-Bionetworks-Workflows/nf-genie/blob/gen-1157-fix-data-guide-copying/scripts/release_utils/consortium_to_bpc.py#L177-L182) to add the testing mode to this script
- Updated [`load_to_bpc`](https://github.com/Sage-Bionetworks-Workflows/nf-genie/blob/gen-1157-fix-data-guide-copying/modules/load_to_bpc.nf#L8-L24) to be able to work on test mode

Mermaid diagram of our nextflow workflow with new changes:
<img width="1206" alt="image" src="https://github.com/Sage-Bionetworks-Workflows/nf-genie/assets/26471741/3b392c36-5ae5-4360-9d70-6778c5825416">


**Testing**
- Added unit tests
- Tested this locally on ec2, and `load_to_bpc` will run after `create_data_guide` finishes