### PR TITLE
[GEN-1204] Use updated sage image for data guide docker

### DIFF
--- a/modules/create_data_guide.nf
+++ b/modules/create_data_guide.nf
@@ -1,7 +1,7 @@
 // Create data guide
 process create_data_guide {
     debug true
-    container 'rxu153/update_tinytex_version:latest'
+    container 'sagebionetworks/genie-data-guide:latest'
     secret 'SYNAPSE_AUTH_TOKEN'
 
     input:


### PR DESCRIPTION
Due to tinytex issues, Rixing used a personal image, lets switch back since the container has been rebuilt.