### PR TITLE
Update to dev ghcr docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,30 +72,30 @@ Note that all the docker parameters have set default docker containers based on 
 * **Only validate** files on test pipeline
 
     ```
-    nextflow -profile aws_test run main.nf --process_type only_validate -with-docker sagebionetworks/genie:latest
+    nextflow run main.nf -profile aws_test --process_type only_validate -with-docker sagebionetworks/genie:latest
     ```
 
 * Processes **non-mutation** files on test pipeline
 
     ```
-    nextflow -profile aws_test run main.nf --process_type main_process -with-docker sagebionetworks/genie:latest
+    nextflow run main.nf -profile aws_test --process_type main_process -with-docker sagebionetworks/genie:latest
     ```
 
 * Processes **mutation** files on test pipeline
 
     ```
-    nextflow -profile aws_test run main.nf --process_type maf_process --create_new_maf_db -with-docker sagebionetworks/genie:latest
+    nextflow run main.nf -profile aws_test --process_type maf_process --create_new_maf_db -with-docker sagebionetworks/genie:latest
     ```
 
 * Runs **processing** and **consortium** release (including data guide creation) on test pipeline
     ```
-    nextflow -profile aws_test run main.nf --process_type consortium_release --create_new_maf_db -with-docker sagebionetworks/genie:latest
+    nextflow run main.nf -profile aws_test --process_type consortium_release --create_new_maf_db -with-docker sagebionetworks/genie:latest
     ```
 
 * Runs **public** release (including data guide creation) on test pipeline
 
     ```
-    nextflow -profile aws_test run main.nf --process_type public_release -with-docker sagebionetworks/genie:latest
+    nextflow run main.nf -profile aws_test --process_type public_release -with-docker sagebionetworks/genie:latest
     ```
 
 ### Testing

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,7 +18,7 @@ profiles {
 		}
 		params {
 			// docker image parameters, see nextflow_schema.json for details
-			main_pipeline_docker = "sagebionetworks/genie:develop"
+			main_pipeline_docker = "ghcr.io/sage-bionetworks/genie:develop"
 			main_release_utils_docker = "sagebionetworks/main-genie-release-utils"
 			find_maf_artifacts_docker = "sagebionetworks/genie-artifact-finder"
 			create_data_guide_docker = "sagebionetworks/genie-data-guide"


### PR DESCRIPTION
**Purpose:** Update the default container for the `aws_test` profile's `main_pipeline_docker` param to use the GHCR develop docker image instead.

**Testing:**
- Ran pipeline on nextflow locally successfully