### PR TITLE
[GEN-863] Modularize patch code by splitting off patch_file function

### DIFF
--- a/scripts/patch_release/compare_patch.py
+++ b/scripts/patch_release/compare_patch.py
@@ -2,8 +2,11 @@
 The command ran: 
 python patch.py syn53170398 syn62069187 syn54082015
 In leu of lack of unit or integration tests, the above command replicates the 
- this is to test 15.5-consortium (syn55146141) and 15.6-consortium (Staging)
+this is to test 15.5-consortium (syn55146141) and 15.6-consortium (Staging)
 
+python compare_patch.py
+
+TODO: Add argparse
 """
 import synapseclient
 import synapseutils as synu

--- a/scripts/patch_release/patch.py
+++ b/scripts/patch_release/patch.py
@@ -89,6 +89,9 @@ def patch_file(syn: synapseclient.Synapse, synid: str, tempdir: str, new_release
         new_release_synid (str): The Synapse ID of the release folder where the patched file will be stored.
         keep_values (pd.Series): The values to keep in the dataframe.
         column (str): The column name to filter on.
+
+    Returns:
+        str: The file path to the patched file
     """
     entity = syn.get(synid, followLink=True)
     df = _filter_tsv(filepath=entity.path, keep_values=keep_values, column=column)
@@ -103,7 +106,7 @@ def patch_file(syn: synapseclient.Synapse, synid: str, tempdir: str, new_release
     with open(new_path, "w") as o_file:
         o_file.write(dftext)
     store_file(syn, new_path, new_release_synid)
-    # TODO: return a named tuple so its not just returning the path
+    # TODO: return a named tuple if needed (YAGNI for now)
     return new_path
 
 

--- a/scripts/patch_release/patch.py
+++ b/scripts/patch_release/patch.py
@@ -60,7 +60,7 @@ def _filter_tsv(filepath: str, keep_values: pd.Series, column: str) -> pd.DataFr
 
 # TODO remove new_release parameter soon
 def store_file(
-    syn: synapseclient.Synapse, new_path: str, new_release_synid: str, new_release: str = None
+    syn: synapseclient.Synapse, new_path: str, new_release_synid: str
 ) -> None:
     """
     Stores a file into Synapse.
@@ -93,7 +93,7 @@ def patch_file(syn: synapseclient.Synapse, synid: str, tempdir: str, new_release
         None
     """
     entity = syn.get(synid, followLink=True)
-    df = _filter_tsv(path=entity.path, keep_values=keep_values, column=column)
+    df = _filter_tsv(filepath=entity.path, keep_values=keep_values, column=column)
     # Specific filtering fro the data gene matrix file because the string NA must
     # replace the blank values
     if entity.name == "data_gene_matrix.txt":
@@ -205,7 +205,7 @@ def patch_release_workflow(
     # public release code rely on the merged clinical file.
     full_clin_df = full_clin_df[full_clin_df["SAMPLE_ID"].isin(keep_samples)]
     full_clin_df.to_csv(clinical_path, sep="\t", index=False)
-    store_file(syn, clinical_path, new_release_synid, new_release)
+    store_file(syn, clinical_path, new_release_synid)
 
     sample_path = os.path.join(tempdir, os.path.basename(sample_ent.path))
     patient_path = os.path.join(tempdir, os.path.basename(patient_ent.path))

--- a/scripts/patch_release/patch.py
+++ b/scripts/patch_release/patch.py
@@ -247,27 +247,10 @@ def patch_release_workflow(
     sampledf = pd.read_csv(sample_ent.path, sep="\t", comment="#")
     centers = [patient.split("-")[1] for patient in sampledf.PATIENT_ID]
     sampledf["CENTER"] = centers
-    # Retract samples from SEQ_ASSAY_ID, CENTER and retract samples list
-    # to_remove_seqassay_rows = sampledf["SEQ_ASSAY_ID"].isin(remove_seqassays)
-    # sampledf = sampledf[~to_remove_seqassay_rows]
-    # to_remove_center_rows = sampledf["CENTER"].isin(remove_centers)
-    # sampledf = sampledf[~to_remove_center_rows]
+    # Retract samples from retract samples list
+    # TODO: Add code here to support redaction for entire center or seq assays
     to_remove_samples = sampledf["SAMPLE_ID"].isin(retracted_samplesdf.SAMPLE_ID)
     final_sampledf = sampledf[~to_remove_samples]
-    # Check number of seq assay ids is the same after removal of samples
-    # Must add to removal of seq assay list for gene panel removal
-    # seq_assay_after = final_sampledf["SEQ_ASSAY_ID"].unique()
-    # seq_assay_before = sampledf["SEQ_ASSAY_ID"].unique()
-    # if len(seq_assay_after) != len(seq_assay_before):
-    #     remove_seqassays.extend(
-    #         seq_assay_before[~seq_assay_before.isin(seq_assay_after)].tolist()
-    #     )
-    # Check number of centers is the same after removal of samples
-    # Must add to removal of seq assay list for gene panel removal
-    # center_after = final_sampledf["CENTER"].unique()
-    # center_before = sampledf["CENTER"].unique()
-    # if len(center_after) != len(center_before):
-    #     remove_centers.extend(center_before[~center_before.isin(center_after)].tolist())
 
     del final_sampledf["CENTER"]
 
@@ -307,6 +290,7 @@ def patch_release_workflow(
     )
     store_file(syn=syn, new_path=sample_path, new_release_synid=new_release_synid)
     store_file(syn=syn, new_path=patient_path, new_release_synid=new_release_synid)
+
     # Patch CNA file
     patch_cna_file(syn=syn, cna_synid=cna_synid, tempdir=tempdir, new_release_synid=new_release_synid, keep_samples=keep_samples)
 
@@ -330,23 +314,10 @@ def patch_release_workflow(
 
     # Create cBioPortal case lists
     patch_case_list_files(syn=syn, new_release_synid=new_release_synid, tempdir=tempdir, clinical_path=clinical_path, assay_path=assay_path)
+
     # Create cBioPortal gene panel and meta files
-    # for name in file_mapping:
-    #     if name.startswith("data_gene_panel"):
-    #         seq_name = name.replace("data_gene_panel_", "").replace(".txt", "")
-    #         if seq_name not in keep_seq_assay_id:
-    #             continue
-    #         gene_panel_ent = syn.get(file_mapping[name], followLink=True)
-    #         new_panel_path = os.path.join(tempdir, os.path.basename(gene_panel_ent.path))
-    #         shutil.copyfile(gene_panel_ent.path, new_panel_path)
-    #         store_file(syn, new_panel_path, new_release_synid)
-    #     elif name.startswith("meta") or "_meta_" in name:
-    #         meta_ent = syn.get(file_mapping[name], followLink=True)
-    #         new_meta_path = os.path.join(tempdir, os.path.basename(meta_ent.path))
-    #         shutil.copyfile(meta_ent.path, new_meta_path)
-    #         revise_meta_file(new_meta_path, old_release, new_release)
-    #         store_file(syn, new_meta_path, new_release_synid)
     patch_gene_panel_and_meta_files(syn=syn, file_mapping=file_mapping, tempdir=tempdir, new_release_synid=new_release_synid, keep_seq_assay_id=keep_seq_assay_id, old_release=old_release, new_release=new_release)
+
     tempdir_o.cleanup()
     # Update dashboard tables
     # Data base mapping synid

--- a/scripts/patch_release/patch.py
+++ b/scripts/patch_release/patch.py
@@ -117,12 +117,10 @@ def patch_release_workflow(
     variables need to be changed to reflect different Synapse ids per release.
     """
     syn = synapseclient.login()
-    # Update dashboard tables
-    # Data base mapping synid
 
+    # TODO: Add ability to provide list of centers / seq assay ids to remove
     # remove_centers = []
     # remove_seqassays = []
-    # release_synid = ""  # Fill in synapse id here
     old_release = syn.get(release_synid).name
     new_release = syn.get(new_release_synid).name
 
@@ -265,7 +263,7 @@ def patch_release_workflow(
     for case_filename in case_list_files:
         # if case_filename in case_file_synids:
         case_path = os.path.join(case_list_path, case_filename)
-        store_file(syn, case_path, case_list_folder_synid, new_release)
+        store_file(syn, case_path, case_list_folder_synid)
 
     # Create cBioPortal gene panel and meta files
     for name in file_mapping:
@@ -276,13 +274,13 @@ def patch_release_workflow(
             gene_panel_ent = syn.get(file_mapping[name], followLink=True)
             new_panel_path = os.path.join(tempdir, os.path.basename(gene_panel_ent.path))
             shutil.copyfile(gene_panel_ent.path, new_panel_path)
-            store_file(syn, new_panel_path, new_release_synid, new_release)
+            store_file(syn, new_panel_path, new_release_synid)
         elif name.startswith("meta") or "_meta_" in name:
             meta_ent = syn.get(file_mapping[name], followLink=True)
             new_meta_path = os.path.join(tempdir, os.path.basename(meta_ent.path))
             shutil.copyfile(meta_ent.path, new_meta_path)
             revise_meta_file(new_meta_path, old_release, new_release)
-            store_file(syn, new_meta_path, new_release_synid, new_release)
+            store_file(syn, new_meta_path, new_release_synid)
 
     tempdir_o.cleanup()
     # Update dashboard tables


### PR DESCRIPTION
Create patch_file function that reduces duplication of code.

Ran the same comparison code as indicated in #21 and there were no changes in the file outputs

Will link the repo after the code is reviewed