### PR TITLE
[GEN-1614] bump memory for consortium release process

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -32,7 +32,7 @@ profiles {
 				cpus = 4
 			}
 			withName: create_consortium_release {
-				memory = 32.GB
+				memory = 64.GB
 				cpus = 4
 			}
 			withName: create_public_release {


### PR DESCRIPTION
Problem:

Ran into out of memory error when doing the 17.5 consortium release

Solution:

Bumping up the memory for this process.