### PR TITLE
[GEN-1473] Update staging seq_date for 16.5 aacrgenie package release

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -45,7 +45,7 @@ release, seq
 */
 def public_map = [
   "TEST": "Jan-2022",
-  "STAGING": "Jul-2024",
+  "STAGING": "Jul-2025",
   "11": "Jan-2022",
   "12": "Jul-2022",
   "13": "Jan-2023",
@@ -59,7 +59,7 @@ def public_map = [
 ]
 def consortium_map = [
   "TEST": "Jul-2022",
-  "STAGING": "Jul-2024",
+  "STAGING": "Jan-2025",
   "11": "Jul-2021",
   "12": "Jan-2022",
   "13": "Jul-2022",


### PR DESCRIPTION
**Purpose:** This updates the public and consortium release seq_date values for the STAGING pipeline to match the current 18.2 consortium release run to have results be comparable.