### PR TITLE
[GEN-1909] Customize copy_recursive function because access requirements are now added to the data

### DIFF
--- a/scripts/release_utils/consortium_to_bpc.py
+++ b/scripts/release_utils/consortium_to_bpc.py
@@ -246,7 +246,6 @@ def main(release: str, test: bool) -> None:
                 syn,
                 ent,
                 genepanel_folder_ent.id,
-                setProvnance=None,
                 updateExisting=True,
                 skipCopyAnnotations=True,
             )
@@ -265,7 +264,6 @@ def main(release: str, test: bool) -> None:
             syn,
             ent,
             caselist_folder_ent.id,
-            setProvnance=None,
             updateExisting=True,
             skipCopyAnnotations=True,
         )
@@ -286,7 +284,6 @@ def main(release: str, test: bool) -> None:
                 syn,
                 ent,
                 bpc_folder_ent.id,
-                setProvnance=None,
                 updateExisting=True,
                 skipCopyAnnotations=True,
             )

--- a/scripts/release_utils/consortium_to_bpc.py
+++ b/scripts/release_utils/consortium_to_bpc.py
@@ -72,6 +72,9 @@ def _copyRecursive(
     **kwargs,
 ) -> Dict[str, str]:
     """
+    NOTE: This is a copy of the function found here: https://github.com/Sage-Bionetworks/synapsePythonClient/blob/develop/synapseutils/copy_functions.py#L409
+    This was copied because there is a restriction that doesn't allow for copying entities with access requirements
+
     Recursively copies synapse entites, but does not copy the wikis
 
     Arguments:

--- a/scripts/release_utils/consortium_to_bpc.py
+++ b/scripts/release_utils/consortium_to_bpc.py
@@ -5,7 +5,7 @@ import argparse
 from typing import Dict
 
 import synapseclient
-from synapseclient import Folder
+from synapseclient import Folder, Project, File, Link, Schema, Entity
 import synapseutils as synu
 
 
@@ -64,8 +64,8 @@ def find_release(
 
 
 def remove_gene_panels(syn, file_mapping, remove_seqassays, remove_centers):
-    """ NOTE: Is this still needed?
-        Removes gene panels that shouldn't be there
+    """NOTE: Is this still needed?
+    Removes gene panels that shouldn't be there
     """
     for name in file_mapping:
         gene_name = name.replace("data_gene_panel_", "").replace(".txt", "")
@@ -73,6 +73,125 @@ def remove_gene_panels(syn, file_mapping, remove_seqassays, remove_centers):
             print(name)
             print(file_mapping[name])
             syn.delete(file_mapping[name])
+
+
+def _copyRecursive(
+    syn: synapseclient.Synapse,
+    entity: str,
+    destinationId: str,
+    mapping: Dict[str, str] = None,
+    skipCopyAnnotations: bool = False,
+    **kwargs,
+) -> Dict[str, str]:
+    """
+    Recursively copies synapse entites, but does not copy the wikis
+
+    Arguments:
+        syn: A Synapse object with user's login
+        entity: A synapse entity ID
+        destinationId: Synapse ID of a folder/project that the copied entity is being copied to
+        mapping: A mapping of the old entities to the new entities
+        skipCopyAnnotations: Skips copying the annotations
+                                Default is False
+
+    Returns:
+        a mapping between the original and copied entity: {'syn1234':'syn33455'}
+    """
+
+    version = kwargs.get("version", None)
+    setProvenance = kwargs.get("setProvenance", "traceback")
+    excludeTypes = kwargs.get("excludeTypes", [])
+    updateExisting = kwargs.get("updateExisting", False)
+    if mapping is None:
+        mapping = dict()
+    # Check that passed in excludeTypes is file, table, and link
+    if not isinstance(excludeTypes, list):
+        raise ValueError("Excluded types must be a list")
+    elif not all([i in ["file", "link", "table"] for i in excludeTypes]):
+        raise ValueError(
+            "Excluded types can only be a list of these values: file, table, and link"
+        )
+
+    ent = syn.get(entity, downloadFile=False)
+    if ent.id == destinationId:
+        raise ValueError("destinationId cannot be the same as entity id")
+
+    if (isinstance(ent, Project) or isinstance(ent, Folder)) and version is not None:
+        raise ValueError("Cannot specify version when copying a project of folder")
+
+    if not isinstance(ent, (Project, Folder, File, Link, Schema, Entity)):
+        raise ValueError("Not able to copy this type of file")
+
+    permissions = syn.restGET("/entity/{}/permissions".format(ent.id))
+    # Don't copy entities without DOWNLOAD permissions
+    if not permissions["canDownload"]:
+        syn.logger.warning(
+            "%s not copied - this file lacks download permission" % ent.id
+        )
+        return mapping
+
+    copiedId = None
+
+    if isinstance(ent, Project):
+        project = syn.get(destinationId)
+        if not isinstance(project, Project):
+            raise ValueError(
+                "You must give a destinationId of a new project to copy projects"
+            )
+        copiedId = destinationId
+        # Projects include Docker repos, and Docker repos cannot be copied
+        # with the Synapse rest API. Entity views currently also aren't
+        # supported
+        entities = syn.getChildren(
+            entity, includeTypes=["folder", "file", "table", "link"]
+        )
+        for i in entities:
+            mapping = _copyRecursive(
+                syn,
+                i["id"],
+                destinationId,
+                mapping=mapping,
+                skipCopyAnnotations=skipCopyAnnotations,
+                **kwargs,
+            )
+
+        if not skipCopyAnnotations:
+            project.annotations = ent.annotations
+            syn.store(project)
+    elif isinstance(ent, Folder):
+        copiedId = synu.copy_functions._copyFolder(
+            syn,
+            ent.id,
+            destinationId,
+            mapping=mapping,
+            skipCopyAnnotations=skipCopyAnnotations,
+            **kwargs,
+        )
+    elif isinstance(ent, File) and "file" not in excludeTypes:
+        copiedId = synu.copy_functions._copyFile(
+            syn,
+            ent.id,
+            destinationId,
+            version=version,
+            updateExisting=updateExisting,
+            setProvenance=setProvenance,
+            skipCopyAnnotations=skipCopyAnnotations,
+        )
+    elif isinstance(ent, Link) and "link" not in excludeTypes:
+        copiedId = synu.copy_functions._copyLink(
+            syn, ent.id, destinationId, updateExisting=updateExisting
+        )
+    elif isinstance(ent, Schema) and "table" not in excludeTypes:
+        copiedId = synu.copy_functions._copyTable(
+            syn, ent.id, destinationId, updateExisting=updateExisting
+        )
+    # This is currently done because copyLink returns None sometimes
+    if copiedId is not None:
+        mapping[ent.id] = copiedId
+        syn.logger.info("Copied %s to %s" % (ent.id, copiedId))
+    else:
+        syn.logger.info("%s not copied" % ent.id)
+    return mapping
 
 
 def main(release: str, test: bool) -> None:
@@ -120,14 +239,22 @@ def main(release: str, test: bool) -> None:
     for name in synid_map:
         if name.startswith("data_gene_panel_"):
             ent = syn.get(synid_map[name], followLink=True, downloadFile=False)
-            synu.copy(
+            _copyRecursive(
                 syn,
                 ent,
                 genepanel_folder_ent.id,
-                setProvnance=None,
-                updateExisting=True,
                 skipCopyAnnotations=True,
+                setProvenance=None,
+                updateExisting=True,
             )
+            # synu.copy(
+            #     syn,
+            #     ent,
+            #     genepanel_folder_ent.id,
+            #     setProvnance=None,
+            #     updateExisting=True,
+            #     skipCopyAnnotations=True,
+            # )
     # Remove gene panels
     for name in genepanel_map:
         if name not in synid_map:
@@ -139,15 +266,22 @@ def main(release: str, test: bool) -> None:
     # Copy case lists
     for name in new_caselist_map:
         ent = syn.get(new_caselist_map[name], followLink=True, downloadFile=False)
-        synu.copy(
+        # synu.copy(
+        #     syn,
+        #     ent,
+        #     caselist_folder_ent.id,
+        #     setProvnance=None,
+        #     updateExisting=True,
+        #     skipCopyAnnotations=True,
+        # )
+        _copyRecursive(
             syn,
             ent,
             caselist_folder_ent.id,
-            setProvnance=None,
-            updateExisting=True,
             skipCopyAnnotations=True,
+            setProvenance=None,
+            updateExisting=True,
         )
-
     # Remove case lists
     for name in caselist_map:
         if name not in new_caselist_map:
@@ -161,13 +295,21 @@ def main(release: str, test: bool) -> None:
         #                            "case_lists")) or name.endswith(".html")
         if not name.startswith(("data_gene_panel_", "data_clinical.txt", "case_lists")):
             ent = syn.get(synid_map[name], followLink=True, downloadFile=False)
-            synu.copy(
+            # synu.copy(
+            #     syn,
+            #     ent,
+            #     bpc_folder_ent.id,
+            #     setProvnance=None,
+            #     updateExisting=True,
+            #     skipCopyAnnotations=True,
+            # )
+            _copyRecursive(
                 syn,
                 ent,
                 bpc_folder_ent.id,
-                setProvnance=None,
-                updateExisting=True,
                 skipCopyAnnotations=True,
+                setProvenance=None,
+                updateExisting=True,
             )
 
 

--- a/scripts/release_utils/consortium_to_bpc.py
+++ b/scripts/release_utils/consortium_to_bpc.py
@@ -235,26 +235,21 @@ def main(release: str, test: bool) -> None:
     release_files = syn.getChildren(release_synid)
     synid_map = {release["name"]: release["id"] for release in release_files}
 
+    #HACK: Copy functions from synapseutils won't work because files have access restrictions
+    synu.copy_functions._copyRecursive = _copyRecursive
+
     # Copy gene panel files
     for name in synid_map:
         if name.startswith("data_gene_panel_"):
             ent = syn.get(synid_map[name], followLink=True, downloadFile=False)
-            _copyRecursive(
+            synu.copy(
                 syn,
                 ent,
                 genepanel_folder_ent.id,
-                skipCopyAnnotations=True,
-                setProvenance=None,
+                setProvnance=None,
                 updateExisting=True,
+                skipCopyAnnotations=True,
             )
-            # synu.copy(
-            #     syn,
-            #     ent,
-            #     genepanel_folder_ent.id,
-            #     setProvnance=None,
-            #     updateExisting=True,
-            #     skipCopyAnnotations=True,
-            # )
     # Remove gene panels
     for name in genepanel_map:
         if name not in synid_map:
@@ -266,21 +261,13 @@ def main(release: str, test: bool) -> None:
     # Copy case lists
     for name in new_caselist_map:
         ent = syn.get(new_caselist_map[name], followLink=True, downloadFile=False)
-        # synu.copy(
-        #     syn,
-        #     ent,
-        #     caselist_folder_ent.id,
-        #     setProvnance=None,
-        #     updateExisting=True,
-        #     skipCopyAnnotations=True,
-        # )
-        _copyRecursive(
+        synu.copy(
             syn,
             ent,
             caselist_folder_ent.id,
-            skipCopyAnnotations=True,
-            setProvenance=None,
+            setProvnance=None,
             updateExisting=True,
+            skipCopyAnnotations=True,
         )
     # Remove case lists
     for name in caselist_map:
@@ -295,21 +282,13 @@ def main(release: str, test: bool) -> None:
         #                            "case_lists")) or name.endswith(".html")
         if not name.startswith(("data_gene_panel_", "data_clinical.txt", "case_lists")):
             ent = syn.get(synid_map[name], followLink=True, downloadFile=False)
-            # synu.copy(
-            #     syn,
-            #     ent,
-            #     bpc_folder_ent.id,
-            #     setProvnance=None,
-            #     updateExisting=True,
-            #     skipCopyAnnotations=True,
-            # )
-            _copyRecursive(
+            synu.copy(
                 syn,
                 ent,
                 bpc_folder_ent.id,
-                skipCopyAnnotations=True,
-                setProvenance=None,
+                setProvnance=None,
                 updateExisting=True,
+                skipCopyAnnotations=True,
             )
 
 

--- a/scripts/release_utils/consortium_to_bpc.py
+++ b/scripts/release_utils/consortium_to_bpc.py
@@ -63,18 +63,6 @@ def find_release(
         return releasedf.iloc[0, 0]
 
 
-def remove_gene_panels(syn, file_mapping, remove_seqassays, remove_centers):
-    """NOTE: Is this still needed?
-    Removes gene panels that shouldn't be there
-    """
-    for name in file_mapping:
-        gene_name = name.replace("data_gene_panel_", "").replace(".txt", "")
-        if gene_name in remove_seqassays or gene_name.startswith(tuple(remove_centers)):
-            print(name)
-            print(file_mapping[name])
-            syn.delete(file_mapping[name])
-
-
 def _copyRecursive(
     syn: synapseclient.Synapse,
     entity: str,

--- a/scripts/release_utils/consortium_to_bpc.py
+++ b/scripts/release_utils/consortium_to_bpc.py
@@ -121,6 +121,9 @@ def _copyRecursive(
         )
         return mapping
 
+    # HACK: These lines of code were removed to allow for data with access requirements to be copied
+    # https://github.com/Sage-Bionetworks/synapsePythonClient/blob/2909fa778e814f62f6fe6ce2d951ce58c0080a4e/synapseutils/copy_functions.py#L464-L470
+
     copiedId = None
 
     if isinstance(ent, Project):


### PR DESCRIPTION
# **Problem:**

* 18.3-consortium needed to be re-copied because a center's data was removed
* `synu.copy`'s implementation prevents data from being copied if it has an access requirement. This is an intentional inconvenience.

# **Solution:**

* manually ran this code
* copied the synu.copy_functions._copyRecursive function and removed the protective portion of the code

# **Testing:**

- [x] Make sure 18.3-consortium is copied over
- [x] This script has no tests except manual validation that the data was copied over correctly