### PR TITLE
[GEN-1959] Ignore null cpt_genie_sample_ids during check BPC retraction step due to germline samples

### DIFF
--- a/scripts/release_utils/check_bpc_retraction.py
+++ b/scripts/release_utils/check_bpc_retraction.py
@@ -26,7 +26,7 @@ def main():
 
     # Pull table with full redcap clinical export
     bpc_samples = syn.tableQuery(
-        "SELECT cpt_genie_sample_id FROM syn23285889"
+        "SELECT cpt_genie_sample_id FROM syn23285889 where cpt_genie_sample_id is not null"
     )
     bpc_samples_df = bpc_samples.asDataFrame()
 


### PR DESCRIPTION


# **Problem:**

The check_bpc_retraction step in main GENIE is failing due to null sample ids in the BPC cancer panel test table

# **Solution:**

I pushed the `sagebionetworks/main-genie-release-utils:gen-1959-bpc-retraction` tag manually and relaunched the workflow on SP just to get us over the hump of consoritum release, but this should support empty sample ids

# **Testing:**
See this: https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/genie-bpc-project/watch/2jfgpdi1005I9R