### PR TITLE
Add missing 19 series, correct 20 series in map

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -68,7 +68,8 @@ def consortium_map = [
   "16": "Jan-2024",
   "17": "Jul-2024",
   "18": "Jan-2025",
-  "20": "Jul-2025"
+  "19": "Jul-2025",
+  "20": "Jan-2026"
 ]
 release_split = params.release.tokenize('.')
 major_release = release_split[0]


### PR DESCRIPTION
# **Problem:**
The 19 consortium release series was missing from `consortium_map` variable in `main.nf`.

# **Solution:**
It was added, and the date for the 20 consortium release series is corrected.

# **Testing:**
- Will be validated when running the consortium release