### PR TITLE
[GEN-2152] Allow user-defined maf center list in maf processing step

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,22 @@ Note that all the docker parameters have set default docker containers based on 
     ```
 
 * Processes **mutation** files on test pipeline
-
+1. To execute the MAF process for all centers, you can either specify the `maf_centers` as "ALL" or leave it blank. 
     ```
     nextflow run main.nf -profile aws_test --process_type maf_process --create_new_maf_db -with-docker ghcr.io/sage-bionetworks/genie:main
+    ```
+    Or
+    ```
+    nextflow run main.nf -profile aws_test --process_type maf_process --maf_centers ALL --create_new_maf_db -with-docker ghcr.io/sage-bionetworks/genie:main
+    ```
+2. To execute the MAF process for a single center, you can specify the `maf_centers` parameter using the name of that center.
+    ```
+    nextflow run main.nf -profile aws_test --process_type maf_process --maf_centers TEST --create_new_maf_db -with-docker ghcr.io/sage-bionetworks/genie:main
+    ```
+
+3. To execute the MAF process for multiple centers, you can specify the `maf_centers` as a comma-separated list of center names.
+    ```
+    nextflow run main.nf -profile aws_test --process_type maf_process --maf_centers TEST,SAGE --create_new_maf_db -with-docker ghcr.io/sage-bionetworks/genie:main
     ```
 
 * Runs **processing** and **consortium** release (including data guide creation) on test pipeline

--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ Note that all the docker parameters have set default docker containers based on 
     nextflow run main.nf -profile aws_test --process_type maf_process --maf_centers TEST --create_new_maf_db -with-docker ghcr.io/sage-bionetworks/genie:main
     ```
 
-3. To execute the MAF process for multiple centers, you can specify the `maf_centers` as a comma-separated list of center names.
+3. To execute the MAF process for multiple centers, you can specify the `maf_centers` as a comma-separated list of center names and **append** results to the MAF table.
     ```
-    nextflow run main.nf -profile aws_test --process_type maf_process --maf_centers TEST,SAGE --create_new_maf_db -with-docker ghcr.io/sage-bionetworks/genie:main
+    nextflow run main.nf -profile aws_test --process_type maf_process --maf_centers TEST,SAGE --create_new_maf_db false -with-docker ghcr.io/sage-bionetworks/genie:main
     ```
 
 * Runs **processing** and **consortium** release (including data guide creation) on test pipeline

--- a/main.nf
+++ b/main.nf
@@ -34,11 +34,7 @@ params.release = "TEST.consortium"
 params.maf_centers = "ALL"
 // List of centers to be processed converted from params.maf_centers
 maf_center_list = params.maf_centers?.split(",").toList()
-// If the list contains "ALL", use the predefined list of all centers
-all_centers = ["JHU","DFCI","GRCC","NKI","MSK","UHN","VICC","MDA","WAKE","YALE","UCSF","CRUK","CHOP","VHIO","SCI","PROV","COLU","UCHI","DUKE","UMIAMI"]
-if (params.maf_centers = "ALL") {
-    maf_center_list = all_centers
-}
+
 // Validate input parameters
 WorkflowMain.initialise(workflow, params, log)
 
@@ -98,6 +94,7 @@ if (major_release == "TEST") {
   center_map_synid = "syn11601248"
   is_prod = false
   is_staging = false
+  
 } else if (major_release == "STAGING"){
   project_id = "syn22033066"
   center_map_synid = "syn22089188"
@@ -110,6 +107,16 @@ else {
   center_map_synid = "syn10061452"
   is_prod = true
   is_staging = false
+}
+
+// Extract center list for MAF processing
+if (major_release == "TEST"){
+  all_centers = ["SAGE", "TEST", "GOLD"]
+} else {
+  all_centers = ["JHU","DFCI","GRCC","NKI","MSK","UHN","VICC","MDA","WAKE","YALE","UCSF","CRUK","CHOP","VHIO","SCI","PROV","COLU","UCHI","DUKE","UMIAMI"]
+}
+if (params.maf_centers = "ALL") {
+  maf_center_list = all_centers
 }
 
 def process_maf_helper(maf_centers, ch_project_id, maf_center_list, create_new_maf_db) {

--- a/main.nf
+++ b/main.nf
@@ -14,7 +14,7 @@ include { reset_processing } from './modules/reset_processing'
 include { validate_data } from './modules/validate_data'
 include { process_main } from './modules/process_main'
 include { process_maf } from './modules/process_maf'
-include { process_maf as process_maf_reuse} from './modules/process_maf'
+include { process_maf as process_maf_remaining_centers} from './modules/process_maf'
 
 // SET PARAMETERS
 
@@ -115,7 +115,7 @@ if (major_release == "TEST"){
 } else {
   all_centers = ["JHU","DFCI","GRCC","NKI","MSK","UHN","VICC","MDA","WAKE","YALE","UCSF","CRUK","CHOP","VHIO","SCI","PROV","COLU","UCHI","DUKE","UMIAMI"]
 }
-if (params.maf_centers = "ALL") {
+if (params.maf_centers == "ALL") {
   maf_center_list = all_centers
 }
 
@@ -133,7 +133,7 @@ def process_maf_helper(maf_centers, ch_project_id, maf_center_list, create_new_m
   // Create a channel from the list of centers
   ch_maf_centers = Channel.fromList(maf_center_list)
   // placeholder for previous output
-  previous = false
+  previous = "default"
   // If maf_centers is "ALL", we will process all centers in the maf_center_list
   if (maf_centers == "ALL") {
     // Create a channel to indicate whether it's the first center or not
@@ -142,9 +142,9 @@ def process_maf_helper(maf_centers, ch_project_id, maf_center_list, create_new_m
         remaining: v != maf_center_list[0]
     }
     // Process the first center with createNewMafDb as true
-    process_maf_col1 = process_maf(previous, ch_project_id, ch_maf_centers.first, true).collect()
+    process_maf_first_center = process_maf(previous, ch_project_id, ch_maf_centers.first, true).collect()
     // Process the rest with createNewMafDb as false
-    return process_maf_reuse(process_maf_col1, ch_project_id, ch_maf_centers.remaining, false).collect()
+    return process_maf_remaining_centers(process_maf_first_center, ch_project_id, ch_maf_centers.remaining, false).collect()
 
   } else {
     // Process centers as the specified maf center list

--- a/main.nf
+++ b/main.nf
@@ -24,7 +24,7 @@ include { process_maf } from './modules/process_maf'
 // Different process types (only_validate, main_process, maf_process, consortium_release, public_release)
 params.process_type = "only_validate"
 // Specify center
-params.center = "ALL"
+params.center = ['ALL']
 // to create new maf database
 params.create_new_maf_db = false
 // release name (pass in TEST.public to test the public release scripts)
@@ -119,7 +119,9 @@ workflow {
     validate_data(ch_project_id, ch_center)
     // validate_data.out.view()
   } else if (params.process_type == "maf_process") {
-    process_maf(ch_project_id, ch_center, params.create_new_maf_db)
+    ch_center.each { center ->
+      process_maf(ch_project_id, center, params.create_new_maf_db)
+    }
     // process_maf.out.view()
   } else if (params.process_type == "main_process") {
     process_main("default", ch_project_id, ch_center)

--- a/main.nf
+++ b/main.nf
@@ -140,7 +140,7 @@ def process_maf_helper(maf_centers, ch_project_id, maf_center_list, create_new_m
     return process_maf_reuse(process_maf_col1, ch_project_id, ch_maf_centers.remaining, false).collect()
 
   } else {
-    // Process centers if the process type is "maf_process"
+    // Process centers as the specified maf center list
     return process_maf(previous, ch_project_id, ch_maf_centers, create_new_maf_db).collect()
   }
 }

--- a/main.nf
+++ b/main.nf
@@ -162,12 +162,12 @@ workflow {
     // validate_data.out.view()
   } else if (params.process_type == "maf_process") {
     // Call the function
-    process_maf_helper(params.maf_centers, ch_project_id, ch_maf_centers, params.create_new_maf_db)
+    process_maf_helper(params.maf_centers, ch_project_id, maf_center_list, params.create_new_maf_db)
     // process_maf.out.view()
   } else if (params.process_type == "main_process") {
     process_main("default", ch_project_id, ch_center)
   } else if (params.process_type == "consortium_release") {
-    process_maf_col = process_maf_helper(params.maf_centers, ch_project_id, ch_maf_centers, params.create_new_maf_db)
+    process_maf_col = process_maf_helper(params.maf_centers, ch_project_id, maf_center_list, params.create_new_maf_db)
     process_main(process_maf_col, ch_project_id, ch_center)
     create_consortium_release(process_main.out, ch_release, ch_is_prod, ch_seq_date, ch_is_staging)
     create_data_guide(create_consortium_release.out, ch_release, ch_project_id)

--- a/modules/process_maf.nf
+++ b/modules/process_maf.nf
@@ -8,6 +8,8 @@ process process_maf {
     val center
     val create_new_maf_db
 
+    tag "processing_${center}"
+
     output:
     stdout
 

--- a/modules/process_maf.nf
+++ b/modules/process_maf.nf
@@ -4,6 +4,7 @@ process process_maf {
     secret 'SYNAPSE_AUTH_TOKEN'
 
     input:
+    val previous
     val proj_id
     val center
     val create_new_maf_db

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -27,9 +27,9 @@
                     ]
                 },
                 "center": {
-                    "type": "string",
-                    "description": "Pick a center to process or validate. Defaults to ALL which means all centers. This value should be ALL if you pick consortium release or public release.",
-                    "default": "ALL"
+                    "type": "array",
+                    "description": "The list of centers to process or validate. Defaults to ['ALL'] which means all centers. This value should be ALL if you pick consortium release or public release.",
+                    "default": ["ALL"]
                 },
                 "create_new_maf_db": {
                     "type": "boolean",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -27,9 +27,14 @@
                     ]
                 },
                 "center": {
-                    "type": "array",
-                    "description": "The list of centers to process or validate. Defaults to ['ALL'] which means all centers. This value should be ALL if you pick consortium release or public release.",
-                    "default": ["ALL"]
+                    "type": "string",
+                    "description": "Pick a center to process or validate. Defaults to ALL which means all centers. This value should be ALL if you pick consortium release or public release.",
+                    "default": "ALL"
+                },
+                "maf_centers": {
+                    "type": "string",
+                    "description": "The list of centers to be processed in the MAF processing. Defaults to ALL which means all centers.",
+                    "default": "ALL"
                 },
                 "create_new_maf_db": {
                     "type": "boolean",


### PR DESCRIPTION
# **Problem:**

Currently, maf processing is done sequentially for each site within a for loop in the [bin/input_to_database.py](https://github.com/Sage-Bionetworks/Genie/blob/84ee2358f7c1402af48f63c9c5948d9a74c795b4/bin/input_to_database.py#L197C5-L210C10). If an error occurs in the MAF file from one center, the entire workflow must be restarted from the beginning. To improve efficiency and robustness, we plan to enhance this step so the workflow can resume from the point of failure, avoiding full restarts and accelerating the overall process when possible.

# **Solution:**

1. Refactor nf-genie/main.nf to add  new parameter:`maf_centers` and specify the list of centers to be processed.

2. Utilize Seqera channel to invoke job for each center in the list, `maxForks` in [process_maf.nf](https://github.com/Sage-Bionetworks-Workflows/nf-genie/blob/main/modules/process_maf.nf) to run job sequentially.

3. Using `tag` to indicate the progress and center information

4. Add `maf_centers`  to schemajson file. 

# **Testing:**

Tested in Seqera Platform:
1. ALL maf_centers: https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/genie-bpc-project/watch/3duZ955j1Er0JF
2. User-defined center list without creating new database: https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/genie-bpc-project/watch/5Y9wR961tkZGGl
3. One center: https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/genie-bpc-project/watch/eDpwwxC7ES3Sz