### PR TITLE
[GEN-2230]Add module to sync staging tables with prod for staging mode

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -15,6 +15,7 @@ include { validate_data } from './modules/validate_data'
 include { process_main } from './modules/process_main'
 include { process_maf } from './modules/process_maf'
 include { process_maf as process_maf_remaining_centers} from './modules/process_maf'
+include {sync_staging_table_with_prod} from './modules/sync_staging_table_with_prod'
 
 // SET PARAMETERS
 
@@ -165,6 +166,9 @@ workflow {
   //   reset_processing(center_map_synid)
   //   reset_processing.out.view()
   // }
+  if (major_release == "STAGING") {
+    sync_staging_table_with_prod()
+  }
   if (params.process_type == "only_validate") {
     validate_data(ch_project_id, ch_center)
     // validate_data.out.view()

--- a/modules/sync_staging_table_with_prod.nf
+++ b/modules/sync_staging_table_with_prod.nf
@@ -1,0 +1,17 @@
+// Create data guide
+process sync_staging_table_with_prod {
+    debug true
+    container "$params.main_pipeline_docker"
+    secret 'SYNAPSE_AUTH_TOKEN'
+
+    input:
+    val previous
+
+    output:
+    stdout
+
+    script:
+    """
+    python sync_staging_table_with_prod.py
+    """
+}

--- a/scripts/sync_staging_table_with_prod.py
+++ b/scripts/sync_staging_table_with_prod.py
@@ -1,0 +1,1 @@
+print('synced_table_with_prod')


### PR DESCRIPTION
# **Problem:**

Currently, our staging tables are out of sync with prod because staging was run on newer data, there will be unused data still present in production tables but not in staging. Also, because certain database tables are used in the validation process and processing, we should copy over pre-existing production tables before a staging run to make it more comparable to the production run.

# **Solution:**

Add module to sync staging tables with prod for staging mode

# **Testing:**
(wip.)