### PR TITLE
[GEN-2594] Fix failing CI/CD trigger to rebuild docker image

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -36,8 +36,11 @@ jobs:
     - name: Check for Changes in scripts/${{ matrix.module }}
       id: check_changes
       run: |
+        # catches failed commands (-e), undefined variables (-u)
+        # and failures hidden inside pipes (pipefail)
         set -euo pipefail
 
+        # Determine the appropriate diff base for change detection
         if [ "${{ github.ref_name }}" = "main" ]; then
           if git rev-parse --verify HEAD^ >/dev/null 2>&1; then
             DIFF_BASE="HEAD^"
@@ -47,8 +50,10 @@ jobs:
             exit 0
           fi
         else
+          # For non-main branches, try to use origin/main as the diff base if it's available
           if git rev-parse --verify origin/main >/dev/null 2>&1 && git merge-base --is-ancestor origin/main HEAD; then
             DIFF_BASE="origin/main"
+          # if origin/main is not available, use HEAD^ as a fallback to check for changes in the last commit in the feature branch
           elif git rev-parse --verify HEAD^ >/dev/null 2>&1; then
             DIFF_BASE="HEAD^"
           else
@@ -59,7 +64,7 @@ jobs:
         fi
 
         echo "Using DIFF_BASE=$DIFF_BASE"
-
+        # Check if there are changes in the specified module directory compared to the determined diff base
         if git diff --name-only "$DIFF_BASE" HEAD -- "scripts/${{ matrix.module }}" | grep -q .; then
           echo "CHANGED=true" >> "$GITHUB_ENV"
         else

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -27,7 +27,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 2
-
     - name: Setup Docker buildx
       uses: docker/setup-buildx-action@v3
 
@@ -37,26 +36,35 @@ jobs:
     - name: Check for Changes in scripts/${{ matrix.module }}
       id: check_changes
       run: |
-        # Determine the correct DIFF_BASE
+        set -euo pipefail
+
         if [ "${{ github.ref_name }}" = "main" ]; then
-          # On the main branch, compare with the previous commit (HEAD^)
-          DIFF_BASE="HEAD^"
-        else
-          # On feature branches, compare with origin/main
-          if git merge-base --is-ancestor origin/main HEAD; then
-            DIFF_BASE="origin/main"
+          if git rev-parse --verify HEAD^ >/dev/null 2>&1; then
+            DIFF_BASE="HEAD^"
           else
-            DIFF_BASE=$(git rev-list --max-parents=0 HEAD)  # Use the initial commit as fallback
+            echo "HEAD^ not available; treating scripts/${{ matrix.module }} as changed"
+            echo "CHANGED=true" >> "$GITHUB_ENV"
+            exit 0
+          fi
+        else
+          if git rev-parse --verify origin/main >/dev/null 2>&1 && git merge-base --is-ancestor origin/main HEAD; then
+            DIFF_BASE="origin/main"
+          elif git rev-parse --verify HEAD^ >/dev/null 2>&1; then
+            DIFF_BASE="HEAD^"
+          else
+            echo "No usable diff base; treating scripts/${{ matrix.module }} as changed"
+            echo "CHANGED=true" >> "$GITHUB_ENV"
+            exit 0
           fi
         fi
 
-        # Compare changes between DIFF_BASE and HEAD
-        if git diff --name-only $DIFF_BASE -- scripts/${{ matrix.module }} | grep -q .; then
-          echo "CHANGED=true" >> $GITHUB_ENV
-        else
-          echo "CHANGED=false" >> $GITHUB_ENV
-        fi
+        echo "Using DIFF_BASE=$DIFF_BASE"
 
+        if git diff --name-only "$DIFF_BASE" HEAD -- "scripts/${{ matrix.module }}" | grep -q .; then
+          echo "CHANGED=true" >> "$GITHUB_ENV"
+        else
+          echo "CHANGED=false" >> "$GITHUB_ENV"
+        fi
     - name: Log in to GitHub Container Registry
       if: env.CHANGED == 'true'
       uses: docker/login-action@v3

--- a/scripts/data_guide/README.md
+++ b/scripts/data_guide/README.md
@@ -2,8 +2,8 @@
 
 Add or update your information for your site into the dedicated field and then submit a pull request.
 
-
 ## Running via Service Catalog
+
 Sometimes the nextflow step for the `create_data_guide.nf` will fail due to an issue with the docker image. Here are a list of [known issues and resolutions](https://sagebionetworks.jira.com/wiki/spaces/APGD/pages/2856943651/GENIE+Pipeline+Troubleshooting) (only accessible by Sage employees).  Since troubleshooting for the docker image can easily take over a few days to resolve, try the manual approach to generate the data guide:
 
 [Follow instructions here](https://sagebionetworks.jira.com/wiki/spaces/APGD/pages/2590244872/Service+Catalog+Instance+Setup#Starting-EC2-instance-from-the-Service-Catalog) for using the Service catalog
@@ -37,7 +37,7 @@ Sometimes the nextflow step for the `create_data_guide.nf` will fail due to an i
     python generate_data_guide.py <consortium_release> <project_id>
     ```
 
-8. [Optional] Sometimes depending on the rendering, you may have the front page genie banner be cut off/too big like the below example ![alt text](/img/cut_off_genie_banner.png) To resolve, you will need to adjust [this width in the data_guide.qmd file](https://github.com/Sage-Bionetworks-Workflows/nf-genie/blob/df3796dce8431fc2a86e297a7350058241c1321c/scripts/data_guide/data_guide.qmd#L11) (e.g: used `15cm` instead of `20cm` for the example below)
+7. [Optional] Sometimes depending on the rendering, you may have the front page genie banner be cut off/too big like the below example ![alt text](/img/cut_off_genie_banner.png) To resolve, you will need to adjust [this width in the data_guide.qmd file](https://github.com/Sage-Bionetworks-Workflows/nf-genie/blob/df3796dce8431fc2a86e297a7350058241c1321c/scripts/data_guide/data_guide.qmd#L11) (e.g: used `15cm` instead of `20cm` for the example below)
 
 ### Example command
 


### PR DESCRIPTION
# **Problem:**
CI/CD was failing with a `fatal: bad revision 'HEAD^'` case when checking for changes (to see if docker image should be rebuilt)

JIRA Ticket: https://sagebionetworks.jira.com/browse/GEN-2594

# **Solution:**

Needed to fall back on safer standards with the checking for changes with HEAD. Changed the CI/CD workflow to
validate Git state first. If the HEAD^ state is missing, it still docker builds to make sure we're not missing out on any changes.

1. Validated `HEAD^` before using it
   Previously the workflow assumed the parent commit always existed:

   ```bash
   DIFF_BASE="HEAD^"
   ```

   Now it explicitly checks:

   ```bash
   git rev-parse --verify HEAD^
   ```

   This prevents failures on shallow clones, first commits, rebased histories, or unusual checkout states.

2. Added fallback logic instead of hard failure
   If no valid diff base exists, the workflow now safely falls back to:

   ```bash
   CHANGED=true
   ```

   instead of silently failing or incorrectly skipping builds.

3. Hardened shell execution
   Added:

   ```bash
   set -euo pipefail
   ```

   which improves reliability by catching:

   * failed commands (`-e`)
   * undefined variables (`-u`)
   * failures hidden inside pipes (`pipefail`)

4. Improved branch comparison safety
   Feature branch logic now verifies `origin/main` actually exists before using it:

   ```bash
   git rev-parse --verify origin/main
   ```

   and  falls back to `HEAD^` if merge-base logic cannot be computed.

# **Testing:**
- Data guide docker image successfully got triggered and rebuilt when changes to data guide README was made: https://github.com/Sage-Bionetworks-Workflows/nf-genie/actions/runs/25818709799/job/75853971283
- No docker image triggers when just making changes to the CI/CD yaml file


