### PR TITLE
[GEN-2648] lockdown `notebook` and `juypter` to security fixed versions

### DIFF
--- a/scripts/data_guide/requirements.txt
+++ b/scripts/data_guide/requirements.txt
@@ -3,7 +3,7 @@ nbformat==5.10.4
 matplotlib==3.10.1
 synapseclient[pandas]==4.7.0
 pyyaml==6.0.2
-notebook==7.4.0
-jupyterlab==4.4.0
+notebook==7.5.6
+jupyterlab==4.5.7
 seaborn==0.13.2
 jinja2==3.1.6


### PR DESCRIPTION
# **Problem:**
Fixes security bot vulnerabilities with `jupyterlab` and `notebook`: https://github.com/Sage-Bionetworks-Workflows/nf-genie/security/dependabot
Examples:
- https://github.com/Sage-Bionetworks-Workflows/nf-genie/security/dependabot/4
- https://github.com/Sage-Bionetworks-Workflows/nf-genie/security/dependabot/6

# **Solution:**
Lock down:
`jupyterlab==4.5.7`
`notebook==7.5.6`

# **Testing:**
- Check that data guide looks as expected after fix in test pipeline run ([run here](https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/genie-bpc-project/watch/4R94EKFS7xJ1iv))
<img width="1305" height="365" alt="image" src="https://github.com/user-attachments/assets/44234fa5-9a31-4acc-85c5-f4c56f8a0f40" />
- Checked the data guide PDFs (before and after) difference appears to be the date value on the data guide which is expected
